### PR TITLE
Extraction of LLM model to environment variable

### DIFF
--- a/server/src/config/index.js
+++ b/server/src/config/index.js
@@ -90,6 +90,9 @@ isDefined(S3_BUCKET, "S3_BUCKET");
 const OPEN_AI_KEY = process.env.OPEN_AI_KEY;
 isDefined(OPEN_AI_KEY, "OPEN_AI_KEY");
 
+const OPEN_AI_GEN_MODEL = process.env.OPEN_AI_GEN_MODEL;
+isDefined(OPEN_AI_GEN_MODEL, "OPEN_AI_GEN_MODEL");
+
 const COHERE_API_KEY = process.env.COHERE_API_KEY;
 isDefined(COHERE_API_KEY, "COHERE_API_KEY");
 
@@ -209,6 +212,8 @@ export default Object.freeze({
         rerankerApiKey: COHERE_API_KEY,
         /** Reranker model to be used */
         rerankerModel: COHERE_RERANK_MODEL,
+        /** Generation model to be used */
+        generationModel: OPEN_AI_GEN_MODEL,
     },
     /** Logging related variables */
     logging: {

--- a/server/src/lib/langchain.js
+++ b/server/src/lib/langchain.js
@@ -17,7 +17,11 @@ const CHAT_INPUT_KEY = "question";
 const CHAT_OUTPUT_KEY = "text";
 
 const embeddings = new OpenAIEmbeddings({ openAIApiKey: config.llm.apiKey });
-const chat = new ChatOpenAI({ openAIApiKey: config.llm.apiKey, temperature: config.llm.temperature });
+const chat = new ChatOpenAI({
+    openAIApiKey: config.llm.apiKey,
+    temperature: config.llm.temperature,
+    modelName: config.llm.generationModel,
+});
 
 /** Returns the embeddings instance to be used in the application */
 const getEmbeddings = () => embeddings;


### PR DESCRIPTION
I extracted the LLM to use for generation as an environment variable, setting the 'modelName' property in the ChatOpenAI constructor. 

This change allows the usage of chat GPT 4o mini with LangChain v0.1; however, when migrating to v0.2, we'll need to change it so that it uses the property with the name 'model' in the constructor since it's supposed to use that.